### PR TITLE
fix: i18n 리소스 덮어쓰는 문제 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "private": false,
   "license": "MIT",
-  "version": "2.0.0-rc.12",
+  "version": "2.0.0-rc.13",
   "description": "A WYSIWYG editor and viewer built with TipTap and Tui Image Editor",
   "keywords": [
     "editor",

--- a/src/shared/utils/i18n.ts
+++ b/src/shared/utils/i18n.ts
@@ -26,18 +26,33 @@ function buildEditorResources(): {
 
 const { ko: koEditor, en: enEditor, es: esEditor } = buildEditorResources();
 
-i18n.use(initReactI18next).init({
-  lng: 'ko',
-  fallbackLng: 'ko',
-  ns: [EDITOR_NS],
-  defaultNS: EDITOR_NS,
-  resources: {
-    ko: { [EDITOR_NS]: koEditor },
-    en: { [EDITOR_NS]: enEditor },
-    es: { [EDITOR_NS]: esEditor },
-  },
-  interpolation: { escapeValue: false },
-});
+const editorResources: Record<string, Record<string, string>> = {
+  ko: koEditor,
+  en: enEditor,
+  es: esEditor,
+};
+
+if (!i18n.isInitialized) {
+  // 라이브러리를 단독으로 쓰는 경우: 기존처럼 전역 i18next를 초기화한다.
+  i18n.use(initReactI18next).init({
+    lng: 'ko',
+    fallbackLng: 'ko',
+    ns: [EDITOR_NS],
+    defaultNS: EDITOR_NS,
+    resources: {
+      ko: { [EDITOR_NS]: koEditor },
+      en: { [EDITOR_NS]: enEditor },
+      es: { [EDITOR_NS]: esEditor },
+    },
+    interpolation: { escapeValue: false },
+  });
+} else {
+  // 호스트 앱이 i18next를 소유한 경우: editor 네임스페이스 리소스만 추가하고
+  // defaultNS / ns / lng / fallbackLng 등 전역 옵션은 절대 건드리지 않는다.
+  for (const [lng, resources] of Object.entries(editorResources)) {
+    i18n.addResourceBundle(lng, EDITOR_NS, resources, true, true);
+  }
+}
 
 /** 한글 키 또는 툴바 키로 번역 문구 반환 (현재 locale 기준) */
 export function getTranslate(key: string): string {

--- a/src/white-editor/editor/ui/white-editor.tsx
+++ b/src/white-editor/editor/ui/white-editor.tsx
@@ -34,12 +34,13 @@ export const WhiteEditor = forwardRef<WhiteEditorRef, WhiteEditorProps<unknown>>
     extension,
     showToolbar = true,
     showSelectionToolbar = true,
-    locale = 'ko',
+    locale,
   } = props;
   const t = useTranslate();
 
-  // locale이 변경되면 즉시 i18n 언어를 동기적으로 설정
-  if (i18n.language !== locale) {
+  // locale prop이 명시적으로 주어진 경우에만 i18n 언어를 동기적으로 설정한다.
+  // 호스트 앱이 언어를 관리하는 경우(locale 미지정) 호스트의 언어를 바꾸지 않는다.
+  if (locale !== undefined && i18n.language !== locale) {
     i18n.changeLanguage(locale);
   }
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,7 +22,6 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
        "@/*": [
          "./src/*"


### PR DESCRIPTION
- white-editor가 i18next를 번들 내장 → peer로 전환하면서, 글로벌 i18next 싱글톤에 가드 없이 init()을 호출해 앱의 defaultNS/ns/리소스를 덮어쓰는 문제 발생 
- white-editor 소스에서 isInitialized 가드 + addResourceBundle로 수정