### PR TITLE
feat: 협업(Yjs) 원격 커서/선택 렌더링 서브패스 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ import { WhiteEditor } from '@0ffen/white-editor';
 | `@0ffen/white-editor/editor` | 에디터 전용 | 선택 |
 | `@0ffen/white-editor/viewer` | 뷰어 전용 | 선택 |
 | `@0ffen/white-editor/util` | 유틸 함수만 (`getHtmlContent`, `createEmptyContent`, `checkEditorEmpty`, `normalizeContentSchema` 등) | 선택 |
+| `@0ffen/white-editor/collaboration` | Yjs 협업 원격 커서/선택 렌더링 (`CollaborationCaret`) | 협업 사용 시 |
 | `@0ffen/white-editor/style.css` | UI 스타일시트 | ✓ |
+| `@0ffen/white-editor/collaboration.css` | 협업 원격 커서/선택 스타일 | 협업 사용 시 |
 | `@0ffen/white-editor/katex.css` | KaTeX 스타일 + 폰트 | 수식 사용 시 |
 | `@0ffen/white-editor/codeblock.css` | D2Coding 코드블록 모노스페이스 폰트 (~3MB) | 코드 폰트 필요 시 |
 | `@0ffen/white-editor/pretendard.css` | Pretendard Variable 폰트 (~2MB) | Pretendard 직접 동봉 필요 시 |
@@ -177,5 +179,52 @@ import '@0ffen/white-editor/katex.css'; // 수식 사용 시에만
 ```
 
 폰트는 `woff2`만 동봉되며, 컨슈머 번들러(Vite/Webpack/Turbopack)가 자동으로 폰트 경로를 처리합니다. 수식을 쓰지 않는 컨슈머는 import를 생략해 ~300KB 폰트를 받지 않을 수 있습니다.
+
+## 협업 (Yjs Collaboration, opt-in)
+
+`@0ffen/white-editor/collaboration` 서브패스는 Yjs 협업 환경에서 **원격 커서/선택 렌더링**을 담당하는 `CollaborationCaret` extension을 제공합니다. 공식 `@tiptap/extension-collaboration-caret`과 달리, 이미지 같은 block 노드의 NodeSelection을 "노드 다음 줄 캐럿"이 아닌 **노드 외곽선 + 사용자 이름 라벨**로 표시합니다.
+
+문서 동기화(`@tiptap/extension-collaboration`)와 provider(y-websocket, Hocuspocus 등)는 컨슈머가 직접 설치/구성합니다. white-editor는 커서/선택 렌더링만 제공합니다.
+
+### 설치
+
+```bash
+pnpm add yjs @tiptap/extension-collaboration @tiptap/y-tiptap y-websocket
+```
+
+`yjs`, `@tiptap/y-tiptap`은 optional peerDependency입니다 — 협업을 쓰지 않는 컨슈머는 설치할 필요가 없고, 메인 번들(`/`, `/editor`, `/viewer`)에는 yjs가 포함되지 않습니다.
+
+### 사용
+
+```tsx
+import Collaboration from '@tiptap/extension-collaboration';
+import { WebsocketProvider } from 'y-websocket';
+import * as Y from 'yjs';
+import { WhiteEditor } from '@0ffen/white-editor';
+import { CollaborationCaret } from '@0ffen/white-editor/collaboration';
+
+import '@0ffen/white-editor/style.css';
+import '@0ffen/white-editor/collaboration.css';
+
+const ydoc = new Y.Doc();
+const provider = new WebsocketProvider('ws://localhost:1234', 'my-room', ydoc);
+
+<WhiteEditor
+  addExtensions={[
+    Collaboration.configure({ document: ydoc }),
+    CollaborationCaret.configure({
+      provider, // { awareness }를 노출하는 어떤 provider든 가능 (y-websocket / Hocuspocus / y-webrtc)
+      user: { name: '사용자명', color: '#3279ec' },
+    }),
+  ]}
+  overrideExtensions={{ starterKit: { undoRedo: false } }}
+/>;
+```
+
+### 주의사항
+
+- **`overrideExtensions: { starterKit: { undoRedo: false } }` 필수** — Collaboration이 Y.UndoManager 기반 undo/redo 커맨드를 재등록하므로 StarterKit 기본 히스토리를 꺼야 합니다 (TipTap v3 옵션 키는 `history`가 아닌 `undoRedo`). 툴바의 undo/redo 버튼은 그대로 동작합니다.
+- **`content`를 넘기지 마세요** — Collaboration 사용 시 에디터에 초기 `content`를 넘기면 접속할 때마다 내용이 중복 삽입됩니다. 초기 내용은 Y.Doc에 1회만 주입하세요.
+- provider의 connect/disconnect 생명주기(StrictMode 이중 mount 포함)는 앱 책임입니다. white-editor는 `provider.awareness`만 소비합니다.
 
 Next.js(App Router), React 19에서 정적 import로 사용할 수 있도록 `"use client"`가 포함되어 있습니다.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "private": false,
   "license": "MIT",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A WYSIWYG editor and viewer built with TipTap and Tui Image Editor",
   "keywords": [
     "editor",
@@ -56,6 +56,11 @@
       "import": "./dist/theme-style.js",
       "types": "./dist/theme-style.d.ts"
     },
+    "./collaboration": {
+      "import": "./dist/collaboration.js",
+      "types": "./dist/collaboration.d.ts"
+    },
+    "./collaboration.css": "./dist/collaboration.css",
     "./style.css": "./dist/style.css",
     "./dist/index.css": "./dist/style.css",
     "./katex.css": "./dist/katex.css",
@@ -138,9 +143,19 @@
     "@tiptap/core": "^3.17.1",
     "@tiptap/pm": "^3.17.1",
     "@tiptap/react": "^3.17.1",
+    "@tiptap/y-tiptap": "^3.0.0",
     "i18next": "^25.8.0",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "yjs": "^13.6.0"
+  },
+  "peerDependenciesMeta": {
+    "@tiptap/y-tiptap": {
+      "optional": true
+    },
+    "yjs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",
@@ -149,6 +164,7 @@
     "@tailwindcss/postcss": "^4.1.13",
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.13",
+    "@tiptap/y-tiptap": "^3.0.4",
     "@types/lodash-es": "^4.17.12",
     "@types/markdown-it": "^14.1.2",
     "@types/node": "^24.4.0",
@@ -178,6 +194,7 @@
     "vite-plugin-dts": "^4.5.4",
     "vite-plugin-static-copy": "^3.2.0",
     "vite-plugin-svgr": "^4.5.0",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-tsconfig-paths": "^5.1.4",
+    "yjs": "^13.6.31"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.13
         version: 4.1.13(vite@7.1.5(@types/node@24.4.0)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.92.1)(sass@1.92.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(yaml@2.8.1))
+      '@tiptap/y-tiptap':
+        specifier: ^3.0.4
+        version: 3.0.4(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -291,6 +294,9 @@ importers:
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.8.3)(vite@7.1.5(@types/node@24.4.0)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.92.1)(sass@1.92.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(yaml@2.8.1))
+      yjs:
+        specifier: ^13.6.31
+        version: 13.6.31
 
 packages:
 
@@ -1827,6 +1833,16 @@ packages:
     peerDependencies:
       '@tiptap/core': ^3.4.6
       '@tiptap/pm': ^3.4.6
+
+  '@tiptap/y-tiptap@3.0.4':
+    resolution: {integrity: sha512-I7NnntIPR9PgCuBEjZ0hco+eeLvTpMDnXxsyhwn8z7Se0/Ac6RIq903wn6KoMn7FRVXpTtXAfZphFtpErjabVw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      prosemirror-model: ^1.7.1
+      prosemirror-state: ^1.2.3
+      prosemirror-view: ^1.9.10
+      y-protocols: ^1.0.1
+      yjs: ^13.5.38
 
   '@toast-ui/react-image-editor@3.15.2':
     resolution: {integrity: sha512-oVLidJ03RsFiS+QpqqLiOvhEw7nhdAeaNRL+UNvjW8He5lYP9wh/l4SkOMhH7UGI6bZq7W950Y19mGKK3fl5+Q==}
@@ -3523,6 +3539,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isomorphic.js@0.2.5:
+    resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
+
   isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
@@ -3636,6 +3655,11 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lib0@0.2.117:
+    resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
+    engines: {node: '>=16'}
+    hasBin: true
 
   lightningcss-darwin-arm64@1.30.1:
     resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
@@ -5236,6 +5260,12 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  y-protocols@1.0.7:
+    resolution: {integrity: sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      yjs: ^13.0.0
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -5270,6 +5300,10 @@ packages:
   yargs@18.0.0:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yjs@13.6.31:
+    resolution: {integrity: sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -6787,6 +6821,15 @@ snapshots:
     dependencies:
       '@tiptap/core': 3.17.1(@tiptap/pm@3.17.1)
       '@tiptap/pm': 3.17.1
+
+  '@tiptap/y-tiptap@3.0.4(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)':
+    dependencies:
+      lib0: 0.2.117
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.5
+      y-protocols: 1.0.7(yjs@13.6.31)
+      yjs: 13.6.31
 
   '@toast-ui/react-image-editor@3.15.2(react@19.2.3)':
     dependencies:
@@ -8779,6 +8822,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isomorphic.js@0.2.5: {}
+
   isstream@0.1.2:
     optional: true
 
@@ -8916,6 +8961,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lib0@0.2.117:
+    dependencies:
+      isomorphic.js: 0.2.5
 
   lightningcss-darwin-arm64@1.30.1:
     optional: true
@@ -10611,6 +10660,11 @@ snapshots:
   xmlchars@2.2.0:
     optional: true
 
+  y-protocols@1.0.7(yjs@13.6.31):
+    dependencies:
+      lib0: 0.2.117
+      yjs: 13.6.31
+
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
@@ -10643,6 +10697,10 @@ snapshots:
       string-width: 7.2.0
       y18n: 5.0.8
       yargs-parser: 22.0.0
+
+  yjs@13.6.31:
+    dependencies:
+      lib0: 0.2.117
 
   yocto-queue@0.1.0: {}
 

--- a/src/entries/collaboration.ts
+++ b/src/entries/collaboration.ts
@@ -1,0 +1,16 @@
+/**
+ * Collaboration(Yjs) 전용 진입점.
+ * import { CollaborationCaret } from '@0ffen/white-editor/collaboration'
+ * import '@0ffen/white-editor/collaboration.css'
+ *
+ * yjs / @tiptap/y-tiptap은 optional peerDependency — 이 서브패스를 쓰는 소비자만 설치한다.
+ * @tiptap/extension-collaboration(문서 동기화)은 소비자가 직접 설치/구성한다.
+ * CSS는 style.css에 합쳐지지 않도록 별도 파일(collaboration.css)로 배포한다 (vite.config viteStaticCopy).
+ */
+export { CollaborationCaret } from '@/white-editor/collaboration';
+export type {
+  CollaborationCaretAwareness,
+  CollaborationCaretProvider,
+  CollaborationCaretUser,
+  CollaborationCaretOptions,
+} from '@/white-editor/collaboration';

--- a/src/shared/styles/collaboration.css
+++ b/src/shared/styles/collaboration.css
@@ -1,0 +1,57 @@
+/* 협업(Yjs) 원격 커서/선택 스타일 — opt-in subpath
+   컨슈머: `import '@0ffen/white-editor/collaboration.css'`
+   색상(border/background/outline)은 CollaborationCaret extension이 awareness user.color로 inline 주입한다. */
+
+/* 원격 텍스트 캐럿 — upstream collaboration-caret과 동일한 클래스/DOM 구조 */
+.collaboration-carets__caret {
+  border-left: 1px solid;
+  border-right: 1px solid;
+  margin-left: -1px;
+  margin-right: -1px;
+  pointer-events: none;
+  position: relative;
+  word-break: normal;
+}
+
+/* 캐럿 상단 사용자 이름 라벨 */
+.collaboration-carets__label {
+  border-radius: 3px 3px 3px 0;
+  color: #fff;
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 600;
+  left: -1px;
+  line-height: normal;
+  padding: 0.1rem 0.3rem;
+  position: absolute;
+  top: -1.4em;
+  user-select: none;
+  white-space: nowrap;
+}
+
+/* 원격 NodeSelection(이미지 등 block 노드 선택) 외곽선 — CollaborationCaret이 Decoration.node로 주입 */
+.we-remote-node-selection {
+  position: relative;
+  outline: 2px solid var(--we-remote-selection-color, #ffa500);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* 외곽선 모서리에 사용자 이름 라벨 (data-remote-user 속성에서 읽음) */
+.we-remote-node-selection::after {
+  content: attr(data-remote-user);
+  position: absolute;
+  top: -1.6em;
+  left: -2px;
+  z-index: 10;
+  border-radius: 3px 3px 3px 0;
+  background-color: var(--we-remote-selection-color, #ffa500);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: normal;
+  padding: 0.1rem 0.3rem;
+  user-select: none;
+  pointer-events: none;
+  white-space: nowrap;
+}

--- a/src/white-editor/collaboration/collaboration-caret.ts
+++ b/src/white-editor/collaboration/collaboration-caret.ts
@@ -1,0 +1,303 @@
+import * as Y from 'yjs';
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey, type EditorState, type Transaction } from '@tiptap/pm/state';
+import { Decoration, DecorationSet, type EditorView } from '@tiptap/pm/view';
+import {
+  absolutePositionToRelativePosition,
+  relativePositionToAbsolutePosition,
+  setMeta,
+  ySyncPluginKey,
+} from '@tiptap/y-tiptap';
+
+/**
+ * `@tiptap/extension-collaboration-caret` 대체 extension.
+ *
+ * 기본 커서 플러그인은 원격 선택을 "head 위치 캐럿 위젯 + inline 하이라이트"로만 그려서,
+ * 이미지 같은 block 노드의 NodeSelection이 상대방에게 "노드 다음 줄 캐럿"으로 보인다.
+ * 이 extension은 렌더링을 직접 제어한다:
+ * - 텍스트 캐럿/선택 → 기존과 동일 (캐럿 위젯 + inline 하이라이트)
+ * - block 노드 1개를 감싸는 선택(NodeSelection) → 캐럿 위젯 없이 노드 외곽선 + 이름 라벨
+ *
+ * 로컬 커서 publish(awareness 'cursor' 필드 기록) 로직은 y-tiptap upstream 구현을 따른다.
+ *
+ * provider는 `{ awareness }` 구조만 요구하므로 y-websocket, Hocuspocus, y-webrtc 등
+ * awareness를 노출하는 어떤 provider와도 사용할 수 있다.
+ */
+
+/**
+ * y-protocols/awareness의 Awareness와 구조적으로 호환되는 최소 인터페이스.
+ * y-protocols를 직접 의존하지 않기 위해 패키지 내부에 정의한다.
+ */
+export interface CollaborationCaretAwareness {
+  getStates(): Map<number, Record<string, unknown>>;
+  getLocalState(): Record<string, unknown> | null;
+  setLocalStateField(field: string, value: unknown): void;
+  on(name: string, callback: (...args: never[]) => void): void;
+  off(name: string, callback: (...args: never[]) => void): void;
+}
+
+/** awareness를 노출하는 provider (y-websocket WebsocketProvider, HocuspocusProvider 등) */
+export interface CollaborationCaretProvider {
+  awareness: CollaborationCaretAwareness;
+}
+
+export interface CollaborationCaretUser {
+  name: string;
+  color: string;
+}
+
+export interface CollaborationCaretOptions {
+  /** awareness를 노출하는 Yjs provider. 필수 — 없으면 에디터 생성 시 throw */
+  provider: CollaborationCaretProvider | null;
+  /** 원격 피어에게 보여줄 로컬 사용자 정보 */
+  user: CollaborationCaretUser;
+}
+
+const collaborationCaretKey = new PluginKey<DecorationSet>('whiteCollaborationCaret');
+
+const FALLBACK_COLOR = '#ffa500';
+const SELECTION_ALPHA_HEX = '4D'; // 30% — inline 하이라이트 배경용
+
+function readSyncState(state: EditorState) {
+  const raw: unknown = ySyncPluginKey.getState(state);
+  if (!raw || typeof raw !== 'object') return null;
+  if (!('doc' in raw) || !('type' in raw) || !('binding' in raw)) return null;
+  if ('snapshot' in raw && raw.snapshot != null) return null;
+
+  const { doc: ydoc, type: yType, binding } = raw;
+  if (!(ydoc instanceof Y.Doc) || !(yType instanceof Y.XmlFragment)) return null;
+  if (!binding || typeof binding !== 'object' || !('mapping' in binding)) return null;
+  const { mapping } = binding;
+  if (!(mapping instanceof Map) || mapping.size === 0) return null;
+
+  return { ydoc, yType, mapping };
+}
+
+function isYChangeOrigin(state: EditorState): boolean {
+  const raw: unknown = ySyncPluginKey.getState(state);
+  return !!raw && typeof raw === 'object' && 'isChangeOrigin' in raw && raw.isChangeOrigin === true;
+}
+
+function readUserInfo(value: unknown): CollaborationCaretUser {
+  let name = '';
+  let color = FALLBACK_COLOR;
+  if (value && typeof value === 'object') {
+    if ('name' in value && typeof value.name === 'string') name = value.name;
+    if ('color' in value && typeof value.color === 'string') color = value.color;
+  }
+  return { name, color };
+}
+
+/** 기본 커서 빌더와 동일한 DOM 구조 — collaboration-carets__* CSS와 짝을 이룬다 */
+function createCaretElement(user: CollaborationCaretUser): HTMLElement {
+  const caret = document.createElement('span');
+  caret.classList.add('collaboration-carets__caret');
+  caret.setAttribute('style', `border-color: ${user.color}`);
+
+  const label = document.createElement('div');
+  label.classList.add('collaboration-carets__label');
+  label.setAttribute('style', `background-color: ${user.color}`);
+  label.insertBefore(document.createTextNode(user.name), null);
+
+  caret.insertBefore(label, null);
+  return caret;
+}
+
+function buildDecorations(state: EditorState, awareness: CollaborationCaretAwareness): DecorationSet {
+  const sync = readSyncState(state);
+  if (!sync) return DecorationSet.empty;
+
+  const decorations: Decoration[] = [];
+
+  awareness.getStates().forEach((awarenessState, clientId) => {
+    if (clientId === sync.ydoc.clientID) return;
+
+    const cursor: unknown = awarenessState.cursor;
+    if (!cursor || typeof cursor !== 'object' || !('anchor' in cursor) || !('head' in cursor)) return;
+    if (cursor.anchor == null || cursor.head == null) return;
+
+    const anchor = relativePositionToAbsolutePosition(
+      sync.ydoc,
+      sync.yType,
+      Y.createRelativePositionFromJSON(cursor.anchor),
+      sync.mapping
+    );
+    const head = relativePositionToAbsolutePosition(
+      sync.ydoc,
+      sync.yType,
+      Y.createRelativePositionFromJSON(cursor.head),
+      sync.mapping
+    );
+    if (anchor == null || head == null) return;
+
+    const from = Math.min(anchor, head);
+    const to = Math.max(anchor, head);
+    if (to > state.doc.content.size) return;
+
+    const user = readUserInfo(awarenessState.user);
+
+    // block 노드 1개를 정확히 감싸는 선택(NodeSelection) → 외곽선 + 라벨, 캐럿 위젯 생략
+    const node = from !== to ? state.doc.nodeAt(from) : null;
+    if (node && !node.isInline && !node.isText && from + node.nodeSize === to) {
+      decorations.push(
+        Decoration.node(from, to, {
+          class: 'we-remote-node-selection',
+          style: `--we-remote-selection-color: ${user.color}`,
+          'data-remote-user': user.name,
+        })
+      );
+      return;
+    }
+
+    // 텍스트 캐럿/선택 → 캐럿 위젯 + inline 하이라이트
+    decorations.push(
+      Decoration.widget(head, () => createCaretElement(user), {
+        key: `${clientId}`,
+        side: 10,
+      })
+    );
+    if (from !== to) {
+      decorations.push(
+        Decoration.inline(
+          from,
+          to,
+          { style: `background-color: ${user.color}${SELECTION_ALPHA_HEX}` },
+          { inclusiveEnd: true, inclusiveStart: false }
+        )
+      );
+    }
+  });
+
+  return DecorationSet.create(state.doc, decorations);
+}
+
+function createCaretPlugin(
+  awareness: CollaborationCaretAwareness,
+  user: CollaborationCaretUser
+): Plugin<DecorationSet> {
+  return new Plugin<DecorationSet>({
+    key: collaborationCaretKey,
+    state: {
+      init: (_config: unknown, state: EditorState) => buildDecorations(state, awareness),
+      apply: (tr: Transaction, prev: DecorationSet, _oldState: EditorState, newState: EditorState) => {
+        const meta: unknown = tr.getMeta(collaborationCaretKey);
+        const awarenessUpdated =
+          !!meta && typeof meta === 'object' && 'awarenessUpdated' in meta && meta.awarenessUpdated === true;
+
+        if (awarenessUpdated || isYChangeOrigin(newState) || tr.docChanged) {
+          return buildDecorations(newState, awareness);
+        }
+        return prev.map(tr.mapping, tr.doc);
+      },
+    },
+    props: {
+      decorations: (state: EditorState) => collaborationCaretKey.getState(state),
+    },
+    view: (view: EditorView) => {
+      awareness.setLocalStateField('user', { name: user.name, color: user.color });
+
+      const awarenessListener = () => {
+        if (!view.isDestroyed) {
+          setMeta(view, collaborationCaretKey, { awarenessUpdated: true });
+        }
+      };
+
+      // upstream(y-tiptap cursor-plugin)의 updateCursorInfo 로직을 따른다
+      const updateCursorInfo = () => {
+        const sync = readSyncState(view.state);
+        if (!sync) return;
+
+        const localState: unknown = awareness.getLocalState();
+        const currentCursor: unknown =
+          localState && typeof localState === 'object' && 'cursor' in localState ? localState.cursor : null;
+
+        if (view.hasFocus()) {
+          const { selection } = view.state;
+          const anchor = absolutePositionToRelativePosition(selection.anchor, sync.yType, sync.mapping);
+          const head = absolutePositionToRelativePosition(selection.head, sync.yType, sync.mapping);
+
+          const isSameCursor =
+            !!currentCursor &&
+            typeof currentCursor === 'object' &&
+            'anchor' in currentCursor &&
+            'head' in currentCursor &&
+            Y.compareRelativePositions(Y.createRelativePositionFromJSON(currentCursor.anchor), anchor) &&
+            Y.compareRelativePositions(Y.createRelativePositionFromJSON(currentCursor.head), head);
+
+          if (!isSameCursor) {
+            awareness.setLocalStateField('cursor', { anchor, head });
+          }
+          return;
+        }
+
+        // blur 시: 이 에디터 binding 소유의 커서면 제거
+        if (currentCursor && typeof currentCursor === 'object' && 'anchor' in currentCursor) {
+          const ownsCursor =
+            relativePositionToAbsolutePosition(
+              sync.ydoc,
+              sync.yType,
+              Y.createRelativePositionFromJSON(currentCursor.anchor),
+              sync.mapping
+            ) !== null;
+          if (ownsCursor) {
+            awareness.setLocalStateField('cursor', null);
+          }
+        }
+      };
+
+      awareness.on('change', awarenessListener);
+      view.dom.addEventListener('focusin', updateCursorInfo);
+      view.dom.addEventListener('focusout', updateCursorInfo);
+
+      return {
+        update: updateCursorInfo,
+        destroy: () => {
+          view.dom.removeEventListener('focusin', updateCursorInfo);
+          view.dom.removeEventListener('focusout', updateCursorInfo);
+          awareness.off('change', awarenessListener);
+          awareness.setLocalStateField('cursor', null);
+        },
+      };
+    },
+  });
+}
+
+/**
+ * 원격 커서/선택 렌더링 extension.
+ *
+ * 사용:
+ * ```ts
+ * import Collaboration from '@tiptap/extension-collaboration';
+ * import { CollaborationCaret } from '@0ffen/white-editor/collaboration';
+ * import '@0ffen/white-editor/collaboration.css';
+ *
+ * const extensions = [
+ *   Collaboration.configure({ document: ydoc }),
+ *   CollaborationCaret.configure({ provider, user: { name: '김선임', color: '#3279ec' } }),
+ * ];
+ * ```
+ *
+ * 주의:
+ * - StarterKit 기본 히스토리와 충돌하므로 `overrideExtensions: { starterKit: { undoRedo: false } }` 필요
+ * - Collaboration 사용 시 에디터에 `content`를 넘기면 접속할 때마다 내용이 중복 삽입됨
+ */
+export const CollaborationCaret = Extension.create<CollaborationCaretOptions>({
+  name: 'whiteCollaborationCaret',
+
+  addOptions() {
+    return {
+      provider: null,
+      user: { name: '', color: FALLBACK_COLOR },
+    };
+  },
+
+  addProseMirrorPlugins() {
+    const { provider, user } = this.options;
+    if (!provider) {
+      throw new Error(
+        '[white-editor] CollaborationCaret requires a `provider` option exposing `awareness` (e.g. y-websocket WebsocketProvider).'
+      );
+    }
+    return [createCaretPlugin(provider.awareness, user)];
+  },
+});

--- a/src/white-editor/collaboration/index.ts
+++ b/src/white-editor/collaboration/index.ts
@@ -1,0 +1,15 @@
+/**
+ * 협업(Yjs) 전용 모듈.
+ *
+ * 주의: 이 디렉토리는 src/white-editor/index.ts에서 export하지 않는다.
+ * yjs/@tiptap/y-tiptap은 optional peerDependency라 메인 번들에 포함되면
+ * 비협업 소비자가 설치하지 않은 의존성을 resolve하게 된다.
+ * 반드시 `@0ffen/white-editor/collaboration` 서브패스로만 노출할 것.
+ */
+export { CollaborationCaret } from './collaboration-caret';
+export type {
+  CollaborationCaretAwareness,
+  CollaborationCaretProvider,
+  CollaborationCaretUser,
+  CollaborationCaretOptions,
+} from './collaboration-caret';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,6 +43,13 @@ export default defineConfig({
           src: 'src/shared/styles/codeblock.css',
           dest: '.',
         },
+        // 협업(Yjs) 원격 커서/선택 스타일 — collaboration 서브패스 사용자만 opt-in
+        //   컨슈머: `import '@0ffen/white-editor/collaboration.css'`
+        //   (entry에서 import하면 cssCodeSplit=false로 style.css에 합쳐지므로 정적 복사로 분리)
+        {
+          src: 'src/shared/styles/collaboration.css',
+          dest: '.',
+        },
         // KaTeX CSS를 dist/katex.css로 재배포 (woff2 only). 컨슈머: `import '@0ffen/white-editor/katex.css'`
         {
           src: 'node_modules/katex/dist/katex.min.css',
@@ -93,6 +100,7 @@ export default defineConfig({
         editor: path.resolve(__dirname, './src/entries/editor.ts'),
         viewer: path.resolve(__dirname, './src/entries/viewer.ts'),
         'theme-style': path.resolve(__dirname, './src/entries/theme-style.ts'),
+        collaboration: path.resolve(__dirname, './src/entries/collaboration.ts'),
       },
       formats: ['es'],
     },
@@ -108,6 +116,8 @@ export default defineConfig({
         /^react-dom($|\/)/,
         /^@tiptap\//,
         /^prosemirror-/,
+        // 협업 서브패스 전용 optional peerDependency — 메인 번들에는 도달하지 않음
+        /^yjs($|\/)/,
         // @radix-ui: 직접 의존하는 패키지만 명시. regex로 전부 잡으면 cmdk 등이 내부적으로
         // 쓰는 transitive(@radix-ui/react-primitive, react-id, compose-refs)까지 external로 잡혀
         // 컨슈머 측에서 resolution 실패함.


### PR DESCRIPTION
- @0ffen/white-editor/collaboration: CollaborationCaret extension
  - 공식 @tiptap/extension-collaboration-caret 대체
  - 텍스트 캐럿/선택은 동일하게 캐럿 위젯 + inline 하이라이트로 렌더링
  - block 노드 NodeSelection(이미지 등)은 노드 외곽선 + 사용자 라벨로 렌더링 (공식 구현은 노드 다음 줄에 캐럿이 떠서 UX가 깨짐)
  - provider는 { awareness } 구조 타입만 요구 — y-websocket/Hocuspocus/y-webrtc 호환
- yjs, @tiptap/y-tiptap은 optional peerDependency — 비협업 소비자 영향 없음 (메인 번들 entry 그래프에 yjs 미포함 검증 완료)
- collaboration.css는 style.css와 분리된 opt-in 파일로 배포
- README에 협업 사용법/주의사항(undoRedo 비활성화, content 금지) 문서화
- v2.2.0